### PR TITLE
adding Rust requirement

### DIFF
--- a/for-developers/information-and-settings/requirements.md
+++ b/for-developers/information-and-settings/requirements.md
@@ -13,4 +13,5 @@
 | [GMP](https://gmplib.org/) | `brew install gmp` | [Install GMP Devel](https://github.com/poanetwork/blockscout-terraform/blob/33f68e816e36dc2fb055911fa0372531f0e956e7/modules/stack/libexec/init.sh#L74) |
 | Make | - | `sudo apt install make`if Debian 9 |
 | G++ Compiler | - | `sudo apt install g++`if Debian 9 |
+| Rust | - | [Install Rust](https://www.rust-lang.org/tools/install)
 


### PR DESCRIPTION
when compiling Blockscout, I encounter errors, after a little search found out that Rust is required in order to compile ex_keccak