### PR TITLE
Add Celo to the list of self hosted blockscout instances

### DIFF
--- a/for-projects/supported-projects.md
+++ b/for-projects/supported-projects.md
@@ -164,6 +164,15 @@ description: Hosted Projects list as well as public and private chains using Blo
       </td>
       <td style="text-align:left"></td>
     </tr>
+    <tr>
+      <td style="text-align:left"></td>
+      <td style="text-align:left"></td>
+      <td style="text-align:left"></td>
+      <td style="text-align:left"></td>
+      <td style="text-align:left"><a href="https://explorer.celo.org/">Celo</a>
+      </td>
+      <td style="text-align:left"></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Added Celo to the list of self hosted blockscout instances in supported-projects.md