### PR TITLE
Revert "Document order for transactions"

### DIFF
--- a/for-users/api/graphql.md
+++ b/for-users/api/graphql.md
@@ -106,7 +106,6 @@ Note that transactions can accept the following arguments:
 * first
 * after
 * before
-* order (ASC / DESC)
 
 
 


### PR DESCRIPTION
Reverts blockscout/docs#49 - looks like this has not yet been merged into blockscout.