### PR TITLE
Install node dependencies using `npm ci`

### DIFF
--- a/for-developers/configuration-options/branding-configs.md
+++ b/for-developers/configuration-options/branding-configs.md
@@ -9,7 +9,7 @@ Note: if you've previously deployed and are updating your BlockScout version wit
 
 In order to rebuild new front-end assets run:
 
-1. `cd apps/block_scout_web/assets; npm install && node_modules/webpack/bin/webpack.js --mode production; cd -`
+1. `cd apps/block_scout_web/assets; npm ci && node_modules/webpack/bin/webpack.js --mode production; cd -`
 2. `mix phx.digest`
 {% endhint %}
 

--- a/for-developers/manual-deployment/README.md
+++ b/for-developers/manual-deployment/README.md
@@ -77,8 +77,8 @@ Be careful since it will delete all data from the DB. Don't execute it on produc
 
 11\) Install Node.js dependencies
 
-* `cd apps/block_scout_web/assets; npm install && node_modules/webpack/bin/webpack.js --mode production; cd -`
-* `cd apps/explorer && npm install; cd -`
+* `cd apps/block_scout_web/assets; npm ci && node_modules/webpack/bin/webpack.js --mode production; cd -`
+* `cd apps/explorer && npm ci; cd -`
 
 12\) Build static assets for deployment `mix phx.digest`
 


### PR DESCRIPTION
To match version in the npm lockfile, use `npm ci` to install dependencies instead of `npm install` that will pull updates.