### PR TITLE
fix: document minimum postgres version for v5 compatibility

### DIFF
--- a/for-projects/resource-requirements.md
+++ b/for-projects/resource-requirements.md
@@ -19,7 +19,7 @@ Minimums are listed for an AWS Cloud instance and can be inferred to other hosti
 |                               |                                                                                                                                                                                                                                                                                                               |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Application                   | <ul><li>1x EC2 t3.Medium instance running Linux</li><li>8GB of EBS General Purpose SSD (NVMe)</li></ul>                                                                                                                                                                                                       |
-| Database                      | <ul><li>1x RDS Database running on db.t3.Medium using PostgreSQL</li><li> 500GB of General Purpose SSD (depending on chain size) </li><li>See <a href="../for-developers/information-and-settings/database-storage-requirements.md">Database Storage Requirements</a> for chain-relevant baselines.</li></ul> |
+| Database                      | <ul><li>1x RDS Database running on db.t3.Medium using PostgreSQL v12+</li><li> 500GB of General Purpose SSD (depending on chain size) </li><li>See <a href="../for-developers/information-and-settings/database-storage-requirements.md">Database Storage Requirements</a> for chain-relevant baselines.</li></ul> |
 | Amazon Elastic Load Balancing | <ul><li>Average 100 <strong></strong> new connections/sec per Elastic Load Balancer</li></ul>                                                                                                                                                                                                                 |
 
 {% hint style="info" %}
@@ -39,6 +39,3 @@ For additional information, see:
 * [Node Tracing Requirements](../for-developers/information-and-settings/node-tracing-json-rpc-requirements.md): JSON RPC methods&#x20;
 * [Client Setting Requirements](../for-developers/information-and-settings/client-settings.md): Settings related to client implementations (ie Geth, OpenEthereum, etc)
 {% endhint %}
-
-
-

--- a/jobs/elixir-developer.md
+++ b/jobs/elixir-developer.md
@@ -23,7 +23,7 @@ This position is a unique opportunity to join a small and experienced team of ve
 
 ### Technology Stack
 
-Elixir 1.10.4+, Erlang, Phoenix Framework, Postgres 10+, Node JS 12+, Webpack, Sass, Docker, Github, Prometheus
+Elixir 1.10.4+, Erlang, Phoenix Framework, Postgres 12+, Node JS 12+, Webpack, Sass, Docker, Github, Prometheus
 
 ### Requirements
 


### PR DESCRIPTION
while upgrading kava's deployment of blockscout (starting with testnet @ https://explorer.testnet.kava.io) to v5.1.5, discovered that the version of postgres we were running was incompatible with the some of the migrations,  specifically starting at migration `20230328100414`, the feature being used by that migration was added to postgres in version 12

Error log from when we first attempted the upgrade:

```
6/20/2023, 3:58:58 PM PDT	** (Postgrex.Error) ERROR 25001 (active_sql_transaction) ALTER TYPE ... ADD cannot run inside a transaction block	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(ecto_sql 3.10.1) lib/ecto/adapters/sql.ex:913: Ecto.Adapters.SQL.raise_sql_call_error/1	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(ecto_sql 3.10.1) lib/ecto/adapters/sql.ex:1005: Ecto.Adapters.SQL.execute_ddl/4	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(ecto_sql 3.10.1) lib/ecto/migration/runner.ex:327: Ecto.Migration.Runner.log_and_execute_ddl/3	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(ecto_sql 3.10.1) lib/ecto/migration/runner.ex:117: anonymous fn/6 in Ecto.Migration.Runner.flush/0	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(elixir 1.14.5) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	(ecto_sql 3.10.1) lib/ecto/migration/runner.ex:116: Ecto.Migration.Runner.flush/0	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	nofile:1: (file)	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	2023-06-20T22:58:58.227 application=ecto_sql [info] == Running 20230328100414 Explorer.Repo.Migrations.AddTransactionActionTypes.change/0 forward	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	2023-06-20T22:58:58.227 application=ecto_sql [info] execute "ALTER TYPE transaction_actions_protocol ADD VALUE 'aave_v3'"	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	2023-06-20T22:58:58.213 application=ecto_sql [info] == Migrated 20230217095226 in 0.0s	blockscout-kava-10-testnet-v5
6/20/2023, 3:58:58 PM PDT	2023-06-20T22:58:58.209 application=ecto_sql [info] == Running 20230217095226 Explorer.Repo.Migrations.AddTotalSupplyUpdatedAtBlock.change/0 forward
```