### PR TITLE
Update hardhat verification page

### DIFF
--- a/for-users/verifying-a-smart-contract/hardhat-verification-plugin.md
+++ b/for-users/verifying-a-smart-contract/hardhat-verification-plugin.md
@@ -1,6 +1,6 @@
 # Hardhat Verification Plugin
 
-[Hardhat ](https://hardhat.org/)is a full-featured development environment for contract compilation, deployment and verification. The [Hardhat Etherscan plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) supports contract verification on BlockScout.
+[Hardhat ](https://hardhat.org/)is a full-featured development environment for contract compilation, deployment and verification. The [hardhat-verify plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) supports contract verification on BlockScout.
 
 ## Get Started
 
@@ -28,18 +28,18 @@ Run `npx hardhat` in your project folder and follow the instructions to create (
 
 ### 3) Install plugin
 
-Install the [hardhat-etherscan plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) (requires **v3.0.0+).**
+Install the [hardhat-verify plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) (requires **v3.0.0+).**
 
 **npm**
 
 ```
-npm install --save-dev @nomiclabs/hardhat-etherscan
+npm install --save-dev @nomicfoundation/hardhat-verify
 ```
 
 **yarn**
 
 ```
-yarn add --dev @nomiclabs/hardhat-etherscan
+yarn add --dev @nomicfoundation/hardhat-verify
 ```
 
 ### 4) Add plugin reference to config file
@@ -47,51 +47,24 @@ yarn add --dev @nomiclabs/hardhat-etherscan
 Add the following statement to your `hardhat.config.js`.
 
 ```
-require("@nomiclabs/hardhat-etherscan");
+require("@nomicfoundation/hardhat-verify");
 ```
 
 If using TypeScript, add this to your `hardhat.config.ts.` [More info on using typescript with hardhat available here](https://hardhat.org/guides/typescript.html#typescript-support).
 
 ```
-import "@nomiclabs/hardhat-etherscan";
+import "@nomicfoundation/hardhat-verify";
 ```
 
-## Config File
+## Config File and Unsupported Networks
 
-Your basic [Hardhat config file](https://hardhat.org/config/) (`hardhat.config.js` or `hardhat.config.ts`) will be setup to support the network you are working on. In this example we use the Sokol test network and a `.js` file. &#x20;
+Your basic [Hardhat config file](https://hardhat.org/config/) (`hardhat.config.js` or `hardhat.config.ts`) will be setup to support the network you are working on. In this example we use the Sepolia test network and a `.js` file. &#x20;
 
 Here we add an RPC url without an API key, however some value is still required. You can use any arbitrary string. [More info](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html#multiple-api-keys-and-alternative-block-explorers).
 
 If you prefer, you can migrate to [hardhat-toolbox](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox) to use a plugin bundle.
 
-```
-require("@nomiclabs/hardhat-waffle");
-require("@nomiclabs/hardhat-etherscan");
-require('hardhat-deploy');
-
-let secret = require("./secret");
-
-module.exports = {
-  solidity: "0.8.9",
-  networks: {
-    sokol: {
-      url: 'https://sokol.poa.network/',
-      accounts: [secret.key],
-    }
-  },
-  etherscan: {
-    // Your API key for Etherscan
-    // Obtain one at https://etherscan.io/
-    apiKey: "abc"
-  }
-};
-```
-
-### Add an Unsupported Network
-
-Some chains are not supported by the plugin (to check run `npx hardhat verify --list-networks`)
-
-If your chain is not in the list, you can add a `customChains` object to the config file. It includes:
+In order to use Blockscout explorer for the verification, you have to specify the explorer details under a `customChains` object. It includes: 
 
 * `chainID` - Network chain ID
 * `apiURL` - Block explorer API URL
@@ -101,62 +74,123 @@ If your chain is not in the list, you can add a `customChains` object to the con
 &#x20;Find an extensive list of ChainIDs at [https://chainlist.org/](https://chainlist.org/).
 {% endhint %}
 
-For example, if Sokol were not in the default list, this is how it would be added to the config file. Note the network name in `customChains` must match the  network name in the `apiKey` object.
+For example, here we added Blockscout api endpoints for the Sepolia network to the config file. 
+Note the network name in `customChains` must match the network name in the `apiKey` object.
 
 ```
-etherscan: {
-  apiKey: {
-    sokol: "abc"
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+import "@nomicfoundation/hardhat-verify";
+
+const PRIVATE_KEY = vars.get("PRIVATE_KEY");
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.24",
+  networks: {
+    sepolia: {
+      url: 'https://ethereum-sepolia-rpc.publicnode.com',
+      accounts: [PRIVATE_KEY],
+    },
   },
-  customChains: [
-    {
-      network: "sokol",
-      chainId: 77,
-      urls: {
-        apiURL: "https://blockscout.com/poa/sokol/api",
-        browserURL: "https://blockscout.com/poa/sokol"
+  // npx hardhat verify 0xd69b16ACEF4bd0aCB7E57D4dF0F1AC84D377E96b --network sepolia 123 --force
+  etherscan: {
+    apiKey: {
+      // Is not required by blockscout. Can be any non-empty string
+      sepolia: "abc"
+    },
+    customChains: [
+      {
+        network: "sepolia",
+        chainId: 11155111,
+        urls: {
+          apiURL: "https://eth-sepolia.blockscout.com/api",
+          browserURL: "https://eth-sepolia.blockscout.com/",
+          // apiURL: "https://api-sepolia.etherscan.io/api",
+          // browserURL: "https://sepolia.etherscan.io/",
+          // apiURL: "https://api.etherscan.io/api",
+          // browserURL: "https://etherscan.io/"
+        }
       }
-    }
-  ]
-}
+    ]
+  },
+  sourcify: {
+    enabled: false
+  }
+};
+
+export default config;
 ```
 
 ## Deploy and Verify
 
+For deployment we will use [Hardhat Ignition](https://hardhat.org/ignition/docs/getting-started#overview) - built-in Hardhat deployment system.
+
 ### Deploy
 
 ```
-D:\hard_hat>npx hardhat run scripts\deploy.js --network sokol
-Contract deployed to: 0x8595e22825Ba499dB8C77C5c830c235D80f9C0fa
+D:\hard_hat>npx hardhat ignition deploy ./ignition/modules/Lock.ts --network sepolia
+✔ Confirm deploy to network sepolia (11155111)? … yes
+Compiled 1 Solidity file successfully (evm target: paris).
+Hardhat Ignition 🚀
+
+Deploying [ LockModule ]
+
+Batch #1
+  Executed LockModule#Lock
+
+[ LockModule ] successfully deployed 🚀
+
+Deployed Addresses
+
+LockModule#Lock - 0x15447991b46862f6cF9a5dB358a923f768a9Fadb
 ```
 
 ### Verify
 
-You can include constructor arguments with the verify task.
+The plugin requires you to include constructor arguments with the verify task 
+and ensures that they correspond to expected ABI signature. 
+However, Blockscout ignores those arguments, so you may specify any values that correspond to the ABI. 
 
 ```
 npx hardhat verify --network <network> DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
 ```
 
-Sokol example (no constructors).
+Sepolia example.
 
 ```bash
-D:\hard_hat>npx hardhat verify --network sokol 0x8595e22825Ba499dB8C77C5c830c235D80f9C0fa 
-Nothing to compile
-Compiling 1 file with 0.8.0
+D:\hard_hat>npx hardhat verify --network sepolia 0x15447991b46862f6cF9a5dB358a923f768a9Fadb 1234
 Successfully submitted source code for contract
-contracts/test.sol:Foo at 0x8595e22825Ba499dB8C77C5c830c235D80f9C0fa
-for verification on Etherscan. Waiting for verification result...
+contracts/Lock.sol:Lock at 0x15447991b46862f6cF9a5dB358a923f768a9Fadb
+for verification on the block explorer. Waiting for verification result...
 
-Successfully verified contract Foo on Etherscan.
-https://blockscout.com/poa/sokol/address/0x8595e22825Ba499dB8C77C5c830c235D80f9C0fa#code
+Successfully verified contract Lock on the block explorer.
+https://eth-sepolia.blockscout.com/address/0x15447991b46862f6cF9a5dB358a923f768a9Fadb#code
 ```
 
 {% hint style="info" %}
-Note the verify task will not be listed in the available tasks lists at `npx hardhat --config` but should work as expected.
+Note the verify task may not be listed in the available tasks lists at `npx hardhat --help` but should work as expected.
 
 If not, check you have the minimum required version of the nomiclabs-hardhat-etherscan plugin (v3.0.0+) installed
 {% endhint %}
+
+### Automatically verified contracts
+Sometimes the contract may be automatically verified via [Ethereum Bytecode Database](https://docs.blockscout.com/about/features/ethereum-bytecode-database-microservice#solution-ethereum-bytecode-database-blockscout-ebd) service.
+In that case you may see the following response:
+```bash
+The contract 0x15447991b46862f6cF9a5dB358a923f768a9Fadb has already been verified on Etherscan.
+https://eth-sepolia.blockscout.com/address/0x15447991b46862f6cF9a5dB358a923f768a9Fadb#code
+```
+
+In that case, you may try to enforce using `--force` flag*.
+
+It prevents Hardhat to check if the contract is already verified, and force it to send verification request anyway.
+Notice, that it is helpful only if the contract was automatically verified **partially**. 
+That way, a new verification sources would be saved. If the contract was **fully** verified already, that just returns an error.
+```bash
+npx hardhat verify --network <network> DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1" --force
+```
+
+* The flag is available starting from `@nomicfoundation/hardhat-verify@2.0.7`
 
 ## Confirm Verification on BlockScout
 
@@ -189,5 +223,5 @@ Although you receive an error, the contracts should be verified during the previ
 ## Resources
 
 {% hint style="info" %}
-Learn more about plugin configs, troubleshooting etc. at [https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html)
+Learn more about plugin configs, troubleshooting etc. at [https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify)
 {% endhint %}

--- a/for-users/verifying-a-smart-contract/hardhat-verification-plugin.md
+++ b/for-users/verifying-a-smart-contract/hardhat-verification-plugin.md
@@ -1,6 +1,6 @@
 # Hardhat Verification Plugin
 
-[Hardhat ](https://hardhat.org/)is a full-featured development environment for contract compilation, deployment and verification. The [hardhat-verify plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) supports contract verification on BlockScout.
+[Hardhat ](https://hardhat.org/)is a full-featured development environment for contract compilation, deployment and verification. The [hardhat-verify plugin](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) supports contract verification on BlockScout.
 
 ## Get Started
 
@@ -28,7 +28,7 @@ Run `npx hardhat` in your project folder and follow the instructions to create (
 
 ### 3) Install plugin
 
-Install the [hardhat-verify plugin](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) (requires **v3.0.0+).**
+Install the [hardhat-verify plugin](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify) (requires **v3.0.0+).**
 
 **npm**
 
@@ -60,7 +60,7 @@ import "@nomicfoundation/hardhat-verify";
 
 Your basic [Hardhat config file](https://hardhat.org/config/) (`hardhat.config.js` or `hardhat.config.ts`) will be setup to support the network you are working on. In this example we use the Sepolia test network and a `.js` file. &#x20;
 
-Here we add an RPC url without an API key, however some value is still required. You can use any arbitrary string. [More info](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html#multiple-api-keys-and-alternative-block-explorers).
+Here we add an RPC url without an API key, however some value is still required. You can use any arbitrary string. [More info](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#multiple-api-keys-and-alternative-block-explorers).
 
 If you prefer, you can migrate to [hardhat-toolbox](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox) to use a plugin bundle.
 
@@ -92,7 +92,6 @@ const config: HardhatUserConfig = {
       accounts: [PRIVATE_KEY],
     },
   },
-  // npx hardhat verify 0xd69b16ACEF4bd0aCB7E57D4dF0F1AC84D377E96b --network sepolia 123 --force
   etherscan: {
     apiKey: {
       // Is not required by blockscout. Can be any non-empty string
@@ -105,10 +104,6 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://eth-sepolia.blockscout.com/api",
           browserURL: "https://eth-sepolia.blockscout.com/",
-          // apiURL: "https://api-sepolia.etherscan.io/api",
-          // browserURL: "https://sepolia.etherscan.io/",
-          // apiURL: "https://api.etherscan.io/api",
-          // browserURL: "https://etherscan.io/"
         }
       }
     ]


### PR DESCRIPTION
- `hardhat-verify-etherscan` mentions were changed to the currently used `hardhat-verify` plugin
- Configuration and Unsupported Networks sections were merged, as almost all built-in networks (except deprecated Sokol and Chiado) use Etherscan as default explorer; thus, even for them a custom configuration is required
- Deployment and verification sections were updated to use Sepolia instead of Sokol examples (the contract page was not loading for the specified Sokol contract)
- Added a section for `--force` flag option