### PR TITLE
Fix spelling and capitalization errors

### DIFF
--- a/devs/autoscout.md
+++ b/devs/autoscout.md
@@ -41,7 +41,7 @@ The following parameters are in the Info section. \* parameters are required.
 * **RPC URL\***: The archive node url (https://your-rpc-url)
 * **WS URL**: The websocket url (wss://ws.your-websocket-url)
 * **Custom Domain**: You can use a custom domain for your instance but must configure your DNS and add a DNS `CNAME` record pointing to `autoscout.cname.blockscout.com`
-* **Public RPC URL**: Enables 'add to Metamask button'. Can be the same as the RPC URL if this is a public node.
+* **Public RPC URL**: Enables 'add to MetaMask button'. Can be the same as the RPC URL if this is a public node.
 * **WalletConnect project ID:** Enables the ability for Read and Write functionality with smart contracts. [Learn more about setting one up here](../setup/configuration-options/walletconnect-project-id-for-contract-read-write.md).
 
 ### Branding
@@ -50,7 +50,7 @@ The following parameters are in the Info section. \* parameters are required.
 
 * **Default color theme**: Choose between a light theme and 3 variations of a darker theme.
 * **Default address identicon:** Select from 4 different options for default identicons in your instance.
-* **Vertical or Horizontal menu**: Select vertica for a side menu or horizontal for a top menu.
+* **Vertical or Horizontal menu**: Select vertical for a side menu or horizontal for a top menu.
 * **Full logo URL**:  Add a url link to your full logo image in horizontal format. Supported formats: image/jpeg, image/gif, image/png. Add one for light mode and one for dark mode if desired (users can switch modes manually).
 * **Logo sign (square) URL**: Add a url link to your square logo image in horizontal format. Supported formats: image/jpeg, image/gif, image/png. Add one for light mode and one for dark mode if desired (users can switch modes manually).
 * **Header background gradient and text color**: Choose your desired background color gradients with the selector and choose your preferred text color. You will see a preview in the interface.&#x20;

--- a/devs/replace-links.md
+++ b/devs/replace-links.md
@@ -39,7 +39,7 @@ Replace the Etherscan url in your code with the Blockscout url for a seamless tr
 
 Some newer operations without standards are still handled differently by different explorers. For example:
 
-* Blobs on Blockscout are accessed in different ways depending on the route. For example via the `?tab=blob_txs` query string following a block ([https://eth.blockscout.com/block/20822532?tab=blob\_txs](https://eth.blockscout.com/block/20822532?tab=blob\_txs)) or the `?tab=blobs` query string following a transaction. Blobs on Etherscan are accessed via `#blobinfo` query strign following a block (ie [https://etherscan.io/block/20822532#blobinfo](https://etherscan.io/block/20822532#blobinfo)).
+* Blobs on Blockscout are accessed in different ways depending on the route. For example via the `?tab=blob_txs` query string following a block ([https://eth.blockscout.com/block/20822532?tab=blob\_txs](https://eth.blockscout.com/block/20822532?tab=blob\_txs)) or the `?tab=blobs` query string following a transaction. Blobs on Etherscan are accessed via `#blobinfo` query string following a block (ie [https://etherscan.io/block/20822532#blobinfo](https://etherscan.io/block/20822532#blobinfo)).
 * User Operations (EIP-4337) are displayed on Blockscout via the [https://eth.blockscout.com/ops](https://eth.blockscout.com/ops) url. On Etherscan there is currently no defined route, but User Operations can be viewed with the `Handle Ops` filter applied to the senders address (ie [https://etherscan.io/advanced-filter?fadd=0x20e9695f25413f14e5807b530D0698bd4F155074\&mtd=0x1fad948c\~Handle+Ops\&ps=10\&p=8](https://etherscan.io/advanced-filter?fadd=0x20e9695f25413f14e5807b530D0698bd4F155074\&mtd=0x1fad948c\~Handle+Ops\&ps=10\&p=8))
 
 ## Replace the API link


### PR DESCRIPTION
Fixed:

Corrected Metamask to MetaMask for proper capitalization.
Changed vertica to vertical for correct spelling.
Fixed strign to string for proper spelling.
Why it's useful:
These changes fix spelling and capitalization errors, improving readability and ensuring accuracy in the documentation.