### PR TITLE
Fix Typo in `ubuntu-setup.md`

### DIFF
--- a/setup/deployment/manual-deployment-guide/ubuntu-setup.md
+++ b/setup/deployment/manual-deployment-guide/ubuntu-setup.md
@@ -109,7 +109,7 @@
 
 > sudo systemctl restart postgresql
 
-12. Check new profile that you created at start of adduser replaceing dbusername with your username.
+12. Check new profile that you created at start of adduser replacing dbusername with your username.
 
 > su - dbusername (for Root) or sudo su - dbusername (for user)\
 > **Note**: Replace your dbusername


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `ubuntu-setup.md`

## Description
Corrected a typo in the `ubuntu-setup.md` file to improve documentation clarity.  

### Changes Made:
- **File Modified:** `setup/deployment/manual-deployment-guide/ubuntu-setup.md`
- **Summary of Changes:**
  - Line 109: Replaced "replaceing" with "replacing" for proper spelling.

## Related Issues
<!-- If applicable, link to related issues or discussions. -->
N/A

## Checklist
- [x] The change follows the project's [contributing guidelines](link-to-contributing-guidelines).
- [x] Documentation is clear and accurate after the update.
- [x] No code functionality is impacted by this change.

## Testing
<!-- Describe how the changes were validated. -->
- Verified that the corrected word aligns with standard English spelling.

## Additional Notes
<!-- Add any additional context, such as reasons for the typo correction or relevant discussions. -->
This is a minor documentation fix with no functional impact. Please review to ensure no other typographical errors exist.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to give maintainers access to modify the pull request if needed. -->
